### PR TITLE
Integrate Vulkan 1.2 and enable timeline semaphores

### DIFF
--- a/Doc/Install_Notes_PC.md
+++ b/Doc/Install_Notes_PC.md
@@ -39,6 +39,13 @@ Run the installer executable. You don't have to install the full Visual Studio C
 
 *Please check [GPU Script - Vulkan Version Compatibility](Vulkan_Compatibility.md) before installing Vulkan.*
 
+**If you plan to install Vulkan 1.2, check with your GPU hardware vender to see whether they have a driver that supports it.**
+
+>The LunarG SDK for Vulkan 1.2 currently does not include a Vulkan driver. You will need to check with your GPU hardware vendor for a Vulkan Installable Client Driver (ICD). The SDK will allow you to build Vulkan applications but you will need a Vulkan ICD to execute them. 
+>* [NVIDIA Drivers](https://developer.nvidia.com/vulkan-driver) (Version 440.99 supports Vulkan 1.2)
+>* [AMD Drivers](https://gpuopen.com/vulkan-1-2-driver-available-latest-radeon-software-adrenalin-2020-edition-20-1-2/)
+>* [Intel Drivers](https://downloadcenter.intel.com/product/80939/Graphics-Drivers) (Version 26.20.100.7755 supports Vulkan 1.2)
+
 ### Download the installer for the LunarG VulkanSDK from here:
 
 [https://vulkan.lunarg.com/sdk/home](https://vulkan.lunarg.com/sdk/home)

--- a/Doc/Install_Notes_Ubuntu.md
+++ b/Doc/Install_Notes_Ubuntu.md
@@ -38,38 +38,66 @@ sudo apt install cmake
 
 <img src="images/Install_Notes/ubuntu_about.png" width="600">
 
-For **Intel**:
+Get the latest drivers by enabling a PPA.
 
+For **AMD / Intel**:
+
+The [kisak-mesa PPA](https://launchpad.net/~kisak/+archive/ubuntu/kisak-mesa) or [oiabaf graphics drivers PPA](https://launchpad.net/~oibaf/+archive/ubuntu/graphics-drivers) are good options.
+
+To install drivers using kisak-mesa PPA:
 ```
-sudo apt-get install libvulkan1 libvulkan1:i386 mesa-vulkan-drivers mesa-vulkan-drivers:i386
+sudo add-apt-repository ppa:kisak/kisak-mesa
+sudo apt update
+sudo apt upgrade
+sudo apt install libvulkan1 mesa-vulkan-drivers
 ```
 
-For **AMD**:
+Alternatively, you can use the oiabaf PPA:
 ```
 sudo add-apt-repository ppa:oibaf/graphics-drivers
 sudo apt update
 sudo apt upgrade
-
-sudo apt install libvulkan1 mesa-vulkan-drivers vulkan-utils
+sudo apt install libvulkan1 mesa-vulkan-drivers
 ```
 
 For **NVIDIA**:
+
+Enable the [Proprietary GPU Drivers PPA](https://launchpad.net/~graphics-drivers/+archive/ubuntu/ppa) to get the latest NVIDIA drivers.
+
 ```
 sudo add-apt-repository ppa:graphics-drivers/ppa
+sudp apt update
 sudo apt upgrade
+```
 
-sudo apt install nvidia-graphics-drivers-396 nvidia-settings vulkan vulkan-utils
+You can auto-install the drivers by:
+```
+ubuntu-drivers devices
+sudo ubuntu-drivers autoinstall
+```
+
+Or install a specific driver:
+```
+sudo apt install nvidia-graphics-drivers-440
 ```
 
 *References:*
 * [https://linuxconfig.org/install-and-test-vulkan-on-linux](https://linuxconfig.org/install-and-test-vulkan-on-linux)
 * [https://steamcommunity.com/app/221410/discussions/6/1742227264188882438/](https://steamcommunity.com/app/221410/discussions/6/1742227264188882438/)
+* [https://github.com/lutris/lutris/wiki/Installing-drivers](https://github.com/lutris/lutris/wiki/Installing-drivers)
 
 -----
 
 ## **(3) Install Vulkan**
 
 *Please check [GPU Script - Vulkan Version Compatibility](Vulkan_Compatibility.md) before installing Vulkan.*
+
+**If you plan to install Vulkan 1.2, check with your GPU hardware vender to see whether they have a driver that supports it.**
+
+>The LunarG SDK for Vulkan 1.2 currently does not include a Vulkan driver. You will need to check with your GPU hardware vendor for a Vulkan Installable Client Driver (ICD). The SDK will allow you to build Vulkan applications but you will need a Vulkan ICD to execute them. 
+>* [NVIDIA Drivers](https://developer.nvidia.com/vulkan-driver) (Version 440.48.02 supports Vulkan 1.2)
+>* [AMD Drivers](https://gpuopen.com/vulkan-1-2-driver-available-latest-radeon-software-adrenalin-2020-edition-20-1-2/)
+>* [Intel Drivers](https://downloadcenter.intel.com/product/80939/Graphics-Drivers) (Version 26.20.100.7755 supports Vulkan 1.2)
 
 ### **Option 1:** &emsp; Easy Install With the LunarG VulkanSDK Ubuntu Package <br> *This installs Vulkan to your system paths. <br> Use this option if you do not have Vulkan already installed on your machine.*
 
@@ -81,7 +109,7 @@ sudo apt install nvidia-graphics-drivers-396 nvidia-settings vulkan vulkan-utils
 
 This will install Vulkan to your system.
 
-You can test whether Vulkan is working by running `vkcube` in the terminal. You should see a spinning LunarG cube.
+You can test whether Vulkan is working by running `vkcube` or `vkvia` in the terminal. You should see a spinning LunarG cube.
 
 <img src="images/Install_Notes/ubuntu_vkcube.png" width="500">
 
@@ -93,9 +121,32 @@ You can test whether Vulkan is working by running `vkcube` in the terminal. You 
 
 <img src="images/Install_Notes/ubuntu_vulkansdk.png" width="600">
 
-You can test whether Vulkan is working by running `<PATH TO SDK>/bin/vkcube`. You should see a spinning LunarG cube.
+Unzip the file to a location of your choice.
+
+### Set up the the runtime environment.
+
+This ensures that when you run a Vulkan application, you are using the correct version. 
+
+Manually set the environment variables:
+
+```cpp
+export VULKAN_SDK=~/<PATH TO SDK>/1.1.xx.y/x86_64
+export PATH=$VULKAN_SDK/bin:$PATH
+export LD_LIBRARY_PATH=$VULKAN_SDK/lib:$LD_LIBRARY_PATH
+export VK_LAYER_PATH=$VULKAN_SDK/etc/vulkan/explicit_layer.d
+```
+
+Or run the setup script that is provided in the top-level directory of your SDK installation. Use the source command to load that script into your current shell:
+
+```
+source ~/<PATH TO SDK>/1.1.xx.y/setup-env.sh
+```
+
+You can test whether Vulkan is working by running `<PATH TO SDK>/bin/vkcube` or `<PATH TO SDK>/bin/vkvia`. You should see a spinning LunarG cube.
 
 ### If you have multiple versions of Vulkan installed and want to specify which version to use for the project, update [CMakeLists.txt](../CMakeLists.txt) to specify the path to the VulkanSDK you want to use.
+
+This ensures that the program is compiled with the correct Vulkan header version you want to use.
 
 <img src="images/Install_Notes/ubuntu_customvk.png" width="700">
 
@@ -105,14 +156,14 @@ You can test whether Vulkan is working by running `<PATH TO SDK>/bin/vkcube`. Yo
 
 ### Install boost.
 ```
-sudo apt-get install libboost-all-dev
+sudo apt install libboost-all-dev
 ```
 
 ### Install dependencies for GLFW.
 ```
 cd ~
-sudo apt-get install libxinerama-dev
-sudo apt-get install libxcursor-dev
+sudo apt install libxinerama-dev
+sudo apt install libxcursor-dev
 sudo apt install libosmesa6-dev
 ```
 

--- a/Doc/Vulkan_Compatibility.md
+++ b/Doc/Vulkan_Compatibility.md
@@ -5,6 +5,7 @@
 
 | Version | Windows | Mac | Ubuntu | Comments |
 |:-------:|:-------:|:---:|:------:|----------|
+| 1.2.131.1 | YES | NO | YES | Mac: Drivers are not up to date for supporting Vulkan 1.2 Timeline Semaphore features which are being integrated into GPU Script. <br> Linux: Tested with an NVIDIA graphics card. Not verified for Intel or AMD.|
 | 1.1.130.0 | NO | NO | NO | All Platforms: There is an issue with UniqueSurfaceKHR in version 1.1.130.0. This has been patched and will be included in the next release. See [discussion.](https://github.com/KhronosGroup/Vulkan-Hpp/issues/467) |
 | 1.1.126.0 | NO | YES | YES | Windows: There are issues with vulkan.hpp loading the .dll. See [discussion.](https://github.com/KhronosGroup/Vulkan-Hpp/issues/454) |
 | 1.1.121.2 | YES | - | - | |

--- a/Include/Core/c_VkPipelineBase.cpp
+++ b/Include/Core/c_VkPipelineBase.cpp
@@ -213,6 +213,7 @@ namespace AppCore {
         return GetDevice().createPipelineLayoutUnique( layout_create_info );
         }
 
+#if VK_HEADER_VERSION >= 131 
     vk::UniqueSemaphore VkPipelineBase::CreateSemaphore( vk::SemaphoreType inType, uint64_t inValue ) const {
         
         if ( inType == vk::SemaphoreType::eBinary ) {
@@ -228,6 +229,11 @@ namespace AppCore {
         return GetDevice().createSemaphoreUnique( create_info );
         
     }
+#else
+    vk::UniqueSemaphore VkPipelineBase::CreateSemaphore() const {
+        return GetDevice().createSemaphoreUnique( {} );
+    }
+#endif
 
     vk::UniqueFence VkPipelineBase::CreateFence( bool signaled) const {
         return GetDevice().createFenceUnique( { signaled ? vk::FenceCreateFlagBits::eSignaled : vk::FenceCreateFlags( 0u ) } );

--- a/Include/Core/c_VkPipelineBase.cpp
+++ b/Include/Core/c_VkPipelineBase.cpp
@@ -213,8 +213,20 @@ namespace AppCore {
         return GetDevice().createPipelineLayoutUnique( layout_create_info );
         }
 
-    vk::UniqueSemaphore VkPipelineBase::CreateSemaphore() const {
-        return GetDevice().createSemaphoreUnique( {} );
+    vk::UniqueSemaphore VkPipelineBase::CreateSemaphore( vk::SemaphoreType inType, uint64_t inValue ) const {
+        
+        if ( inType == vk::SemaphoreType::eBinary ) {
+            return GetDevice().createSemaphoreUnique( {} );
+        }
+
+        vk::SemaphoreTypeCreateInfo type_create_info(
+            inType,                                                 // VkSemaphoreType              semaphoreType;
+            inValue                                                 // uint64_t                     initialValue;
+        );
+        vk::SemaphoreCreateInfo create_info;
+        create_info.pNext = &type_create_info;
+        return GetDevice().createSemaphoreUnique( create_info );
+        
     }
 
     vk::UniqueFence VkPipelineBase::CreateFence( bool signaled) const {

--- a/Include/Core/c_VkPipelineBase.h
+++ b/Include/Core/c_VkPipelineBase.h
@@ -39,6 +39,7 @@ namespace AppCore {
         vk::UniqueFramebuffer                 Framebuffer;
         vk::UniqueSemaphore                   ImageAvailableSemaphore;
         vk::UniqueSemaphore                   FinishedRenderingSemaphore;
+        vk::UniqueSemaphore                   TimelineSemaphore;
         vk::UniqueFence                       Fence;
         vk::UniqueCommandPool                 CommandPool;
         vector<vk::UniqueCommandBuffer>       CommandBufferList;
@@ -48,6 +49,7 @@ namespace AppCore {
             Framebuffer(),
             ImageAvailableSemaphore(),
             FinishedRenderingSemaphore(),
+            TimelineSemaphore(),
             Fence(),
             CommandPool(),
             CommandBufferList() {
@@ -120,7 +122,7 @@ namespace AppCore {
         vk::UniqueSampler                     CreateSampler( vk::SamplerMipmapMode mipmap_mode, vk::SamplerAddressMode address_mode, vk::Bool32 unnormalized_coords ) const;
         vk::UniqueRenderPass                  CreateRenderPass( std::vector<RenderPassAttachmentData> const & attachment_descriptions, std::vector<RenderPassSubpassData> const & subpass_descriptions, std::vector<vk::SubpassDependency> const & dependencies ) const;
         vk::UniquePipelineLayout              CreatePipelineLayout( std::vector<vk::DescriptorSetLayout> const & descriptor_set_layouts, std::vector<vk::PushConstantRange> const & push_constant_ranges ) const;
-        vk::UniqueSemaphore                   CreateSemaphore() const;
+        vk::UniqueSemaphore                   CreateSemaphore( vk::SemaphoreType inType = vk::SemaphoreType::eBinary, uint64_t inValue = 0 ) const;
         vk::UniqueFence                       CreateFence( bool signaled ) const;
         vk::UniqueCommandPool                 CreateCommandPool( uint32_t queue_family_index, vk::CommandPoolCreateFlags flags ) const;
         std::vector<vk::UniqueCommandBuffer>  AllocateCommandBuffers( vk::CommandPool const & pool, vk::CommandBufferLevel level, uint32_t count ) const;

--- a/Include/Core/c_VkPipelineBase.h
+++ b/Include/Core/c_VkPipelineBase.h
@@ -122,7 +122,12 @@ namespace AppCore {
         vk::UniqueSampler                     CreateSampler( vk::SamplerMipmapMode mipmap_mode, vk::SamplerAddressMode address_mode, vk::Bool32 unnormalized_coords ) const;
         vk::UniqueRenderPass                  CreateRenderPass( std::vector<RenderPassAttachmentData> const & attachment_descriptions, std::vector<RenderPassSubpassData> const & subpass_descriptions, std::vector<vk::SubpassDependency> const & dependencies ) const;
         vk::UniquePipelineLayout              CreatePipelineLayout( std::vector<vk::DescriptorSetLayout> const & descriptor_set_layouts, std::vector<vk::PushConstantRange> const & push_constant_ranges ) const;
+        
+        #if VK_HEADER_VERSION >= 131 
         vk::UniqueSemaphore                   CreateSemaphore( vk::SemaphoreType inType = vk::SemaphoreType::eBinary, uint64_t inValue = 0 ) const;
+        #else
+        vk::UniqueSemaphore                   CreateSemaphore() const;
+        #endif
         vk::UniqueFence                       CreateFence( bool signaled ) const;
         vk::UniqueCommandPool                 CreateCommandPool( uint32_t queue_family_index, vk::CommandPoolCreateFlags flags ) const;
         std::vector<vk::UniqueCommandBuffer>  AllocateCommandBuffers( vk::CommandPool const & pool, vk::CommandBufferLevel level, uint32_t count ) const;

--- a/Include/Core/c_VulkanBase.cpp
+++ b/Include/Core/c_VulkanBase.cpp
@@ -40,6 +40,11 @@ VKAPI_ATTR void VKAPI_CALL vkDestroyDebugUtilsMessengerEXT(VkInstance instance, 
 }
 // END FOR DEBUGGING ------------------------------------------------------------------------------------------------------------------ //
 
+#if VK_HEADER_VERSION >= 131 
+    #define VULKAN_VERSION_2
+#elif VK_HEADER_VERSION >= 68
+    #define VULKAN_VERSION_1
+#endif
 
 namespace AppCore {
 
@@ -51,9 +56,12 @@ namespace AppCore {
 
     void VulkanBase::InitVulkan( WindowParameters window ) {
         
-        if ( (int) VK_HEADER_VERSION >= 131 ) { Vulkan.Version = VK_MAKE_VERSION( 1, 2, 0 ); }
-        else if ( (int) VK_HEADER_VERSION >= 68 ) { Vulkan.Version = VK_MAKE_VERSION( 1, 1, 0 ); }
-        
+        #if VK_HEADER_VERSION >= 131 
+            Vulkan.Version = VK_MAKE_VERSION( 1, 2, 0 );
+        #elif VK_HEADER_VERSION >= 68
+            Vulkan.Version = VK_MAKE_VERSION( 1, 1, 0 );
+        #endif
+
         Window = window;
 
         CheckVulkanLibrary();

--- a/Include/Core/c_VulkanBase.cpp
+++ b/Include/Core/c_VulkanBase.cpp
@@ -49,15 +49,17 @@ namespace AppCore {
         Window() {
     }
 
-    void VulkanBase::InitVulkan( WindowParameters window, uint32_t version ) {
-        std::cout << "VK_HEADER_VERSION: " << VK_HEADER_VERSION << std::endl;
+    void VulkanBase::InitVulkan( WindowParameters window ) {
+        
+        if ( (int) VK_HEADER_VERSION >= 131 ) { Vulkan.Version = VK_MAKE_VERSION( 1, 2, 0 ); }
+        else if ( (int) VK_HEADER_VERSION >= 68 ) { Vulkan.Version = VK_MAKE_VERSION( 1, 1, 0 ); }
         
         Window = window;
 
         CheckVulkanLibrary();
-        CreateInstance( version );
+        CreateInstance( Vulkan.Version );
         CreatePresentationSurface();
-        CreateDevice( version );
+        CreateDevice( Vulkan.Version );
         GetDeviceQueue();
         CreateSwapChain();
     }
@@ -111,30 +113,44 @@ namespace AppCore {
         }
     }
 
+    int VulkanBase::GetVersion() {
+        return (int) VK_VERSION_MINOR( Vulkan.Version );
+    }
+
 
     void VulkanBase::CreateInstance( uint32_t version ) {
 
         auto available_extensions = vk::enumerateInstanceExtensionProperties();
-        std::vector<const char*> extensions = GetRequiredExtensions();
 
+        // Uncomment to list available instance extensions
+        // for( size_t i = 0; i < available_extensions.size(); ++i ) {
+        //     std::cout << "--- VulkanBase::CreateInstance     Available extensions: " << available_extensions[i].extensionName << std::endl;
+        // }
+
+        std::vector<const char*> extensions = GetRequiredExtensions();                      // Extensions from GLFW
         for( size_t i = 0; i < extensions.size(); ++i ) {
             if( !CheckExtensionAvailability( extensions[i], available_extensions ) ) {
                 throw std::runtime_error( std::string( "Could not find instance extension named \"" + std::string( extensions[i] ) + "\"!" ).c_str() );
             }
         }
 
-        extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);        // FOR DEBUG PURPOSES
+        extensions.push_back(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);                            // Extensions for debug purposes
+
+        // Uncomment to list instance extensions enabled
+        // for( size_t i = 0; i < extensions.size(); ++i ) {
+        //     std::cout << "--- VulkanBase::CreateInstance     Extension Loaded: " << extensions[i] << std::endl;
+        // };
 
         std::vector<const char*> validation_layers = {
             "VK_LAYER_LUNARG_standard_validation",
             "VK_LAYER_KHRONOS_validation"
             // "VK_LAYER_LUNARG_api_dump"
         };
-
+    
         vk::ApplicationInfo application_info(
-            "AppCore",                                      // const char                *pApplicationName
+            "AppCore",                                            // const char                *pApplicationName
             VK_MAKE_VERSION( 1, 0, 0 ),                           // uint32_t                   applicationVersion
-            "AppCore Engine",                               // const char                *pEngineName
+            "AppCore Engine",                                     // const char                *pEngineName
             VK_MAKE_VERSION( 1, 0, 0 ),                           // uint32_t                   engineVersion
             version                                               // uint32_t                   apiVersion
         );
@@ -148,25 +164,27 @@ namespace AppCore {
             extensions.data()                                     // const char * const        *ppEnabledExtensionNames
         );
 
-        //Vulkan.Instance = vk::createInstanceUnique( instance_create_info );
         Vulkan.Instance = vk::createInstance( instance_create_info );
+        std::cout << "--- VulkanBase::CreateInstance    Created Vulkan Instance " << std::endl;
 
-        std::cout << "--- VulkanBase::CreateInstance     Created Vulkan Instance" << std::endl;
+        uint32_t instance_version = vk::enumerateInstanceVersion();
+        uint32_t major_version = VK_VERSION_MAJOR( instance_version );
+        uint32_t minor_version = VK_VERSION_MINOR( instance_version );
+        uint32_t patch_version = VK_VERSION_PATCH( instance_version );
+        std::cout << "--- VulkanBase::CreateInstance    Instance Version " << major_version << " " << minor_version << " " << patch_version << std::endl;
 
         // FOR DEBUG
         static bool initialized = false;
         if (!initialized) {
             pfnVkCreateDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkCreateDebugUtilsMessengerEXT>(Vulkan.Instance.getProcAddr("vkCreateDebugUtilsMessengerEXT"));
             pfnVkDestroyDebugUtilsMessengerEXT = reinterpret_cast<PFN_vkDestroyDebugUtilsMessengerEXT>(Vulkan.Instance.getProcAddr("vkDestroyDebugUtilsMessengerEXT"));
-            std::cout << "--- VulkanBase::CreateInstance     Got to here 1" << std::endl;
             assert(pfnVkCreateDebugUtilsMessengerEXT && pfnVkDestroyDebugUtilsMessengerEXT);
-            std::cout << "--- VulkanBase::CreateInstance     Got to here 2" << std::endl;
             initialized = true;
         }
 
         DebugUtilsMessenger = CreateDebugUtilsMessenger( Vulkan.Instance );
 
-        std::cout << "--- VulkanBase::CreateInstance     Enabled Debug Extension" << std::endl;
+        std::cout << "--- VulkanBase::CreateInstance    Enabled Debug Extension" << std::endl;
 
     }
 
@@ -206,15 +224,30 @@ namespace AppCore {
 
     void VulkanBase::CreateDevice( uint32_t version ) {
 
-        //auto physical_devices = Vulkan.Instance->enumeratePhysicalDevices();
         auto physical_devices = Vulkan.Instance.enumeratePhysicalDevices();
 
         uint32_t selected_graphics_queue_family_index = UINT32_MAX;
         uint32_t selected_present_queue_family_index = UINT32_MAX;
 
+        // Physical device extensions we want to use
+        std::vector<const char*> extensions = {
+            VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+            VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME
+        };
+
         for( auto & physical_device : physical_devices ) {
-            if( CheckPhysicalDeviceProperties( physical_device, selected_graphics_queue_family_index, selected_present_queue_family_index ) ) {
+            if( CheckPhysicalDeviceProperties( physical_device, extensions, selected_graphics_queue_family_index, selected_present_queue_family_index ) ) {
                 Vulkan.PhysicalDevice = physical_device;
+                vk::PhysicalDeviceProperties device_properties = physical_device.getProperties();
+                Vulkan.PhysicalDeviceName = device_properties.deviceName;
+                std::cout << "--- VulkanBase::CreateDevice     Selected Physical Device: " << Vulkan.PhysicalDeviceName << std::endl;
+
+                // Uncomment to show the highest version API supported by the physical device
+                // uint32_t major_version = VK_VERSION_MAJOR( device_properties.apiVersion );
+                // uint32_t minor_version = VK_VERSION_MINOR( device_properties.apiVersion );
+                // uint32_t patch_version = VK_VERSION_PATCH( device_properties.apiVersion );
+                // std::cout << "--- VulkanBase::CreateDevice     Physical Device Supported API: " << major_version << " " << minor_version << " " << patch_version << std::endl;
+                
                 break;
             }
         }
@@ -241,10 +274,11 @@ namespace AppCore {
             );
         }
 
-        std::vector<const char*> extensions = {
-            VK_KHR_SWAPCHAIN_EXTENSION_NAME
-        };
-
+        // Enable the timeline feature in the physical device by adding it to the pNext element of PhysicalDeviceFeatures2
+        vk::PhysicalDeviceFeatures2 device_features = Vulkan.PhysicalDevice.getFeatures2();
+        vk::PhysicalDeviceTimelineSemaphoreFeatures timeline_feature(VK_TRUE);
+        device_features.setPNext( &timeline_feature );
+        
         vk::DeviceCreateInfo device_create_info(
             vk::DeviceCreateFlags( 0 ),                       // VkDeviceCreateFlags                flags
             static_cast<uint32_t>(queue_create_infos.size()), // uint32_t                           queueCreateInfoCount
@@ -255,6 +289,7 @@ namespace AppCore {
             extensions.data(),                                // const char * const                *ppEnabledExtensionNames
             nullptr                                           // const VkPhysicalDeviceFeatures    *pEnabledFeatures
         );
+        device_create_info.setPNext( &device_features );      // PhysicalDeviceFeatures2 added to the pNext element of DeviceCreateInfo
 
         Vulkan.Device = Vulkan.PhysicalDevice.createDeviceUnique( device_create_info );
         Vulkan.GraphicsQueue.FamilyIndex = selected_graphics_queue_family_index;
@@ -264,17 +299,11 @@ namespace AppCore {
     }
 
 
-    bool VulkanBase::CheckPhysicalDeviceProperties( vk::PhysicalDevice const & physical_device, uint32_t & selected_graphics_queue_family_index, uint32_t & selected_present_queue_family_index ) {
+    bool VulkanBase::CheckPhysicalDeviceProperties( vk::PhysicalDevice const & physical_device, std::vector<const char*> device_extensions, uint32_t & selected_graphics_queue_family_index, uint32_t & selected_present_queue_family_index ) {
 
         auto available_extensions = physical_device.enumerateDeviceExtensionProperties();
 
         vk::PhysicalDeviceProperties device_properties = physical_device.getProperties();
-        vk::PhysicalDeviceFeatures   device_features = physical_device.getFeatures();
-        Vulkan.PhysicalDeviceName = device_properties.deviceName;
-
-        std::vector<const char*> device_extensions = {
-            VK_KHR_SWAPCHAIN_EXTENSION_NAME
-        };
 
         for( size_t i = 0; i < device_extensions.size(); ++i ) {
             if( !CheckExtensionAvailability( device_extensions[i], available_extensions ) ) {
@@ -333,9 +362,7 @@ namespace AppCore {
 
     void VulkanBase::GetDeviceQueue() {
         Vulkan.GraphicsQueue.Handle = Vulkan.Device->getQueue( Vulkan.GraphicsQueue.FamilyIndex, 0 );
-        Vulkan.PresentQueue.Handle = Vulkan.Device->getQueue( Vulkan.PresentQueue.FamilyIndex, 0 );
-        
-        std::cout << "--- VulkanBase::GetDeviceQueue     Got Vulkan Device Queues" << std::endl;        
+        Vulkan.PresentQueue.Handle = Vulkan.Device->getQueue( Vulkan.PresentQueue.FamilyIndex, 0 );     
     }
 
 
@@ -481,21 +508,21 @@ namespace AppCore {
 
     vk::ImageUsageFlags VulkanBase::GetSwapChainUsageFlags( vk::SurfaceCapabilitiesKHR const & surface_capabilities, vk::ImageUsageFlags const selected_usage ) const {
 
-        // Print out suported usage flags
-        static bool initialized = false;
-        if ( initialized == false ) {
-            std::cout << "Supported swap chain's image usages include:\n"
-            << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransferSrc             ? "    VK_IMAGE_USAGE_TRANSFER_SRC\n" : "") 
-            << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransferDst             ? "    VK_IMAGE_USAGE_TRANSFER_DST\n" : "") 
-            << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eSampled                 ? "    VK_IMAGE_USAGE_SAMPLED\n" : "") 
-            << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eStorage                 ? "    VK_IMAGE_USAGE_STORAGE\n" : "") 
-            << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eColorAttachment         ? "    VK_IMAGE_USAGE_COLOR_ATTACHMENT\n" : "") 
-            << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eDepthStencilAttachment  ? "    VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT\n" : "") 
-            << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransientAttachment     ? "    VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT\n" : "") 
-            << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eInputAttachment         ? "    VK_IMAGE_USAGE_INPUT_ATTACHMENT" : "")
-            << std::endl;
-            initialized = true;
-        }
+        // Uncomment to print out suported usage flags
+        // static bool initialized = false;
+        // if ( initialized == false ) {
+        //     std::cout << "Supported swap chain's image usages include:\n"
+        //     << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransferSrc             ? "    VK_IMAGE_USAGE_TRANSFER_SRC\n" : "") 
+        //     << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransferDst             ? "    VK_IMAGE_USAGE_TRANSFER_DST\n" : "") 
+        //     << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eSampled                 ? "    VK_IMAGE_USAGE_SAMPLED\n" : "") 
+        //     << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eStorage                 ? "    VK_IMAGE_USAGE_STORAGE\n" : "") 
+        //     << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eColorAttachment         ? "    VK_IMAGE_USAGE_COLOR_ATTACHMENT\n" : "") 
+        //     << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eDepthStencilAttachment  ? "    VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT\n" : "") 
+        //     << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eTransientAttachment     ? "    VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT\n" : "") 
+        //     << (surface_capabilities.supportedUsageFlags & vk::ImageUsageFlagBits::eInputAttachment         ? "    VK_IMAGE_USAGE_INPUT_ATTACHMENT" : "")
+        //     << std::endl;
+        //     initialized = true;
+        // }
         
         // Color attachment flag must always be supported
         // We can define other usage flags but we always need to check if they are supported
@@ -503,11 +530,6 @@ namespace AppCore {
             throw std::runtime_error( std::string( std::string( "VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT image usage is not supported by the swap chain!\n" ) ) );
         }
 
-        // #ifdef __APPLE__
-        // return vk::ImageUsageFlagBits::eColorAttachment;
-        // #else
-        // return vk::ImageUsageFlagBits::eColorAttachment | vk::ImageUsageFlagBits::eInputAttachment;
-        // #endif
         return vk::ImageUsageFlagBits::eColorAttachment;
     }
 

--- a/Include/Core/c_VulkanBase.h
+++ b/Include/Core/c_VulkanBase.h
@@ -138,7 +138,7 @@ namespace AppCore {
     // General Vulkan parameters' container class                   //
     // ************************************************************ //
     struct VulkanBaseParameters {
-        //vk::UniqueInstance            Instance;
+        uint32_t                      Version;
         vk::Instance                  Instance;
         vk::PhysicalDevice            PhysicalDevice;
         std::string                   PhysicalDeviceName;
@@ -149,6 +149,7 @@ namespace AppCore {
         SwapChainParameters           SwapChain;
 
         VulkanBaseParameters() :
+            Version( VK_MAKE_VERSION( 1, 0, 0 ) ),
             Instance(),
             PhysicalDevice(),
             Device(),
@@ -173,7 +174,7 @@ namespace AppCore {
         VulkanBase();
         virtual ~VulkanBase();
 
-        void                            InitVulkan( WindowParameters window, uint32_t version = VK_MAKE_VERSION( 1, 0, 0 ) );
+        void                            InitVulkan( WindowParameters window );
 
         // Overrided methods
         virtual void                    OnWindowSizeChanged() final override;           // Overrided from WindowBase
@@ -186,6 +187,7 @@ namespace AppCore {
         QueueParameters const &         GetPresentQueue() const;
         vk::SurfaceKHR const &          GetPresentationSurface() const;
         SwapChainParameters const &     GetSwapChain() const;
+        int                             GetVersion();
 
         // FOR DEBUG
         vk::UniqueDebugUtilsMessengerEXT    DebugUtilsMessenger;
@@ -194,7 +196,6 @@ namespace AppCore {
     protected:
 
         void                            CreateSwapChain( vk::PresentModeKHR const selected_present_mode = vk::PresentModeKHR::eMailbox, vk::ImageUsageFlags const selected_usage = vk::ImageUsageFlagBits::eColorAttachment, uint32_t const selected_image_count = 3 );
-
 
     private:
 
@@ -205,7 +206,7 @@ namespace AppCore {
         void                            CreateInstance( uint32_t version );
         void                            CreatePresentationSurface();
         void                            CreateDevice( uint32_t version );
-        bool                            CheckPhysicalDeviceProperties( vk::PhysicalDevice const & physical_device, uint32_t & graphics_queue_family_index, uint32_t & present_queue_family_index );
+        bool                            CheckPhysicalDeviceProperties( vk::PhysicalDevice const & physical_device, std::vector<const char*> device_extensions, uint32_t & graphics_queue_family_index, uint32_t & present_queue_family_index );
         void                            GetDeviceQueue();
         void                            CreateSwapChainImageViews();
 

--- a/Include/Layouts/c_LayoutManager.h
+++ b/Include/Layouts/c_LayoutManager.h
@@ -27,7 +27,7 @@ namespace AppCore {
         void                    SetCurrentLayout( int inIndex );
         void                    UpdateCurrentLayout();
 
-        int                     BufferCount = 2;    // Set max number of command buffers needed.
+        int                     BufferCount = 3;    // Set max number of command buffers needed.
         void                    InitStyles();
         void                    InitLayouts();      // Add your layouts here
         

--- a/Include/Layouts/c_PaneTree.h
+++ b/Include/Layouts/c_PaneTree.h
@@ -56,7 +56,6 @@ namespace AppCore {
                 }
                 else {
                     int parentIndex = iter->second;
-
                     //cout << "map " << i << " to parent: " << parentIndex << "\n";
                     Nodes[i].Parent = parentIndex;
                 } 

--- a/Include/ProjectSetup/c_PipelineManager.cpp
+++ b/Include/ProjectSetup/c_PipelineManager.cpp
@@ -56,10 +56,10 @@ namespace AppCore {
     
             frame_resources->ImageAvailableSemaphore = CreateSemaphore();
             frame_resources->FinishedRenderingSemaphore = CreateSemaphore();
-            if (GetVersion() >= 2) {
+            #if VK_HEADER_VERSION >= 131 
                 // Only create timeline sempahore if Vulkan Version is 1.2
                 frame_resources->TimelineSemaphore = CreateSemaphore( vk::SemaphoreType::eTimeline, (uint64_t) 100 );
-            }
+            #endif
             frame_resources->Fence = CreateFence( true );
             frame_resources->CommandPool = CreateCommandPool( GetGraphicsQueue().FamilyIndex, vk::CommandPoolCreateFlagBits::eResetCommandBuffer | vk::CommandPoolCreateFlagBits::eTransient );
             frame_resources->CommandBufferList.resize( LM.BufferCount );

--- a/Include/ProjectSetup/c_PipelineManager.h
+++ b/Include/ProjectSetup/c_PipelineManager.h
@@ -44,6 +44,7 @@ namespace AppCore {
         // Drawing methods
 
         void                        StartFrame( CurrentFrameData & current_frame );
+        void                        AcquireImage( CurrentFrameData & current_frame );
         void                        FinishFrame( CurrentFrameData & current_frame );
 
         void                        OnWindowSizeChanged_Pre() final override;

--- a/Include/ProjectSetup/c_SUI_PipelineBase.h
+++ b/Include/ProjectSetup/c_SUI_PipelineBase.h
@@ -98,8 +98,9 @@ namespace AppCore {
         SUI_PipelineBase( PipelineManager &parent );
         virtual ~SUI_PipelineBase();
 
-        void                    Init( size_t resource_count );
-        virtual void            Render( CurrentFrameData & current_frame, vk::CommandBuffer & command_buffer );
+        void                    Init( size_t resource_count);
+        virtual void            ReInit( int render_order );
+        virtual void            Render( CurrentFrameData & current_frame, vk::CommandBuffer & command_buffer, int render_order );
 
         virtual void            OnWindowSizeChanged_Pre();
         virtual void            OnWindowSizeChanged_Post();
@@ -129,16 +130,16 @@ namespace AppCore {
         virtual void            CreateVertexBuffer();
         virtual void            CreateIndexBuffer();
         virtual void            CreateDescriptorSet();
-        virtual void            CreateRenderPasses();
+        virtual void            CreateRenderPasses(int render_order=0);
         virtual void            CreatePipelineLayout();
         virtual void            CreateGraphicsPipeline();
         virtual void            SubmitComplete();
         
         // Render methods
-        virtual void            AcquireImage( CurrentFrameData & current_frame );
+        virtual void            CreateCurrentFrameBuffer( CurrentFrameData & current_frame );
         virtual void            UpdateUniformBuffer( SUI_PipelineData::DrawResourcesData & drawing_resources );
         virtual void            RecordCommandBuffer( CurrentFrameData & current_frame, vk::CommandBuffer & command_buffer );
-        virtual void            SubmitCommandBuffer( CurrentFrameData & current_frame, vk::CommandBuffer & command_buffer );
+        virtual void            SubmitCommandBuffer( CurrentFrameData & current_frame, vk::CommandBuffer & command_buffer, int render_order );
 
         virtual vk::Rect2D      SetScissor();
         

--- a/Include/User/user_Layouts.cpp
+++ b/Include/User/user_Layouts.cpp
@@ -8,8 +8,6 @@ namespace AppCore {
 
     void LayoutManager::InitLayouts() {
 
-        cout << "------- Running LayoutManager::InitLayouts -------- " << endl;
-
         PTM.AddSUI<UnderlayUI> ( "UnderUI" );
         PTM.AddTUI<ExampleLibraryUI> ( "ExampleLib" );
 
@@ -49,6 +47,14 @@ namespace AppCore {
         PTM.AddPaneTree( "Ice Example", 1,      {   {"Main",            "",              "*",        "*",        "y",        "",     "",     ""     },
                                                     {"IceShader",       "Main",          "*",        "*",        "",         "",     "",     ""     },
                                                     {"IceSliders",      "Main",          "300",      "120",       "",        "",    "-20",  "-20"   }
+        });
+
+        // =============PaneTreeName====LazyUpdate===Name=============ParentName======WidthExp=====HeightExp===Split=======Mode====FloatX==FloatY=== 
+        PTM.AddPaneTree( "MultiSUI Example",  1,    {  {"Main",            "",              "*",        "*",        "y",        "",     "",     ""     },
+                                                    {"OceanSlider",     "Main",          "",         "90",       "",        "",     "",     ""     },
+                                                    {"BottomPane",      "Main",          "*",        "*",        "x",        "",     "",     ""    },
+                                                    {"OceanShader",     "BottomPane",    "50%",        "*",        "",        "",     "",     ""   },
+                                                    {"ParticlesShader", "BottomPane",    "*",        "*",        "",        "",     "",     ""     }
         });
         
 


### PR DESCRIPTION
The follow changes have been added:

Updates to Core and Layout Manager
* Integrate Vulkan 1.2 timeline semaphore capabilities while maintaining Vulkan 1.1 compatibility
* Modifications to allow for multiple SUI pipelines
* Added MultiSUI Example

Updates to the documentation
* Updated Vulkan Version Compatibility table
* Updated Linux graphics driver install notes
* Added links to NVIDIA, AMD, and Intel drivers with Vulkan 1.2 support

Note: Timeline sempahore capabilities are only available if you compile and run with Vulkan 1.2.